### PR TITLE
Allow the use of a configuration file with another name than "config.ini"

### DIFF
--- a/processor.py
+++ b/processor.py
@@ -38,7 +38,7 @@ def parse_arguments():
     if args.config_file:
         dictall = {}
         config = configparser.ConfigParser()
-        config.read('config.ini')
+        config.read(args.config_file)
         cc = config.sections()
         optional_data = defaultdict(lambda: None)
         for c in cc:


### PR DESCRIPTION
This update enables to pass a configuration file with the '-g' option when calling processor.py from the command line with another name than the default "config.ini".